### PR TITLE
Optional Addresses, Styling Hook

### DIFF
--- a/TMEmailHelpers.podspec
+++ b/TMEmailHelpers.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
     s.name                    = "TMEmailHelpers"
-    s.version                 = "0.0.2"
+    s.version                 = "0.0.3"
     s.summary                 = "Email creation helpers"
 
     s.homepage                = "http://github.com/hiimtmac/TMEmailHelpers"
@@ -15,6 +15,8 @@ Pod::Spec.new do |s|
     s.source                  = { :git => "https://github.com/hiimtmac/TMEmailHelpers.git", :tag => s.version }
     s.source_files            = "TMEmailHelpers/**/*.swift"
     s.requires_arc            = true
+    s.framework               = 'MessageUI'
+
     s.dependency 'SwiftyMimes'
 
 end

--- a/TMEmailHelpers/Email.swift
+++ b/TMEmailHelpers/Email.swift
@@ -30,16 +30,22 @@ public struct Email {
         self.attachments = Set(attachments)
     }
     
-    public mutating func addToEmail(_ address: EmailAddress) {
-        to.insert(address)
+    public mutating func addToEmail(_ address: EmailAddress?) {
+        if let address = address {
+            to.insert(address)
+        }
     }
     
-    public mutating func addCcEmail(_ address: EmailAddress) {
-        cc.insert(address)
+    public mutating func addCcEmail(_ address: EmailAddress?) {
+        if let address = address {
+            cc.insert(address)
+        }
     }
     
-    public mutating func addBccEmail(_ address: EmailAddress) {
-        bcc.insert(address)
+    public mutating func addBccEmail(_ address: EmailAddress?) {
+        if let address = address {
+            bcc.insert(address)
+        }
     }
     
     public mutating func addAttachment(_ attachment: EmailAttachment) {

--- a/TMEmailHelpers/EmailPresenting.swift
+++ b/TMEmailHelpers/EmailPresenting.swift
@@ -10,14 +10,19 @@ import Foundation
 import MessageUI
 
 public protocol EmailPresenting: AnyObject {
-    
+    func style(_ controller: MFMailComposeViewController)
 }
 
 extension EmailPresenting where Self: UIViewController & MFMailComposeViewControllerDelegate {
+    public func style(_ controller: MFMailComposeViewController) {
+        
+    }
     
     public func presentEmail(_ email: Email) {
         if MFMailComposeViewController.canSendMail() {
             let mail = MFMailComposeViewController()
+            
+            style(mail)
             
             mail.setSubject(email.subject)
             mail.setToRecipients(email.validTo)

--- a/TMEmailHelpers/Info.plist
+++ b/TMEmailHelpers/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.2</string>
+	<string>0.0.3</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>


### PR DESCRIPTION
adding email addresses now can handle optional strings
styling hook added for `MFMailComposeViewController` in `EmailPresenting` protocol